### PR TITLE
Added CprServiceInterface

### DIFF
--- a/src/Plugin/WebformElement/CprLookupElement.php
+++ b/src/Plugin/WebformElement/CprLookupElement.php
@@ -7,7 +7,7 @@ use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Render\ElementInfoManagerInterface;
 use Drupal\Core\Session\AccountInterface;
-use Drupal\os2forms_cpr_lookup\Service\CprService;
+use Drupal\os2forms_cpr_lookup\Service\CprServiceInterface;
 use Drupal\os2forms_nemid\Plugin\WebformElement\NemidElementBase;
 use Drupal\os2web_nemlogin\Service\AuthProviderService;
 use Drupal\webform\Plugin\WebformElementManagerInterface;
@@ -39,7 +39,7 @@ abstract class CprLookupElement extends NemidElementBase {
   /**
    * The CPR service.
    *
-   * @var \Drupal\os2forms_cpr_lookup\Service\CprService
+   * @var \Drupal\os2forms_cpr_lookup\Service\CprServiceInterface
    */
   private $cprService;
 
@@ -59,7 +59,7 @@ abstract class CprLookupElement extends NemidElementBase {
     WebformTokenManagerInterface $token_manager,
     WebformLibrariesManagerInterface $libraries_manager,
     AuthProviderService $authProviderService,
-    CprService $cprService
+    CprServiceInterface $cprService
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $logger, $config_factory, $current_user,
       $entity_type_manager, $element_info, $element_manager, $token_manager, $libraries_manager);

--- a/src/ProxyClass/Service/CprService.php
+++ b/src/ProxyClass/Service/CprService.php
@@ -12,7 +12,7 @@ namespace Drupal\os2forms_cpr_lookup\ProxyClass\Service {
      *
      * @see \Drupal\Component\ProxyBuilder
      */
-    class CprService
+    class CprService implements \Drupal\os2forms_cpr_lookup\Service\CprServiceInterface
     {
 
         use \Drupal\Core\DependencyInjection\DependencySerializationTrait;

--- a/src/Service/CprService.php
+++ b/src/Service/CprService.php
@@ -16,7 +16,7 @@ use ItkDev\Serviceplatformen\Service\PersonBaseDataExtendedService;
 /**
  * CPR Service.
  */
-class CprService {
+class CprService implements CprServiceInterface {
 
   /**
    * PersonBaseDataExtendedService.
@@ -78,17 +78,9 @@ class CprService {
   }
 
   /**
-   * Performs a call on the Person Base Data Extended service.
-   *
-   * @param string $cpr
-   *   The CPR number to search for.
-   *
-   * @return \Drupal\os2forms_cpr_lookup\CPR\CprServiceResult
-   *   The CPR Service Result.
-   *
-   * @throws \ItkDev\Serviceplatformen\Service\Exception\ServiceException
+   * {@inheritdoc}
    */
-  public function search(string $cpr): CprServiceResult {
+  public function search($cpr) {
     $response = $this->personBaseDataExtendedService->personLookup($cpr);
     return new CprServiceResult($response);
   }

--- a/src/Service/CprServiceInterface.php
+++ b/src/Service/CprServiceInterface.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Drupal\os2forms_cpr_lookup\Service;
+
+/**
+ * CPR Service interface.
+ */
+interface CprServiceInterface {
+
+  /**
+   * Performs a call on the Person Base Data Extended service.
+   *
+   * @param string $cpr
+   *   The CPR number to search for.
+   *
+   * @return \Drupal\os2forms_cpr_lookup\CPR\CprServiceResult
+   *   The CPR Service Result.
+   *
+   * @throws \ItkDev\Serviceplatformen\Service\Exception\ServiceException
+   */
+  public function search($cpr);
+
+}


### PR DESCRIPTION
Adds a CprServiceInterface to make it possible to inject the proxied CprService.

Note: Apparently `generate-proxy-class.php` does not handle argument and return types so these are removed in the interface and implementation.
